### PR TITLE
1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ A mod that brings "touch" controls to Balatro on PC/Mac, making it a bit more fu
 
 This mod has been tested against **Balatro 1.0.1o** (current patch as of February 26, 2025) on PC/Mac using code from the same patch on iOS. It has also been reported to work great on Steam Deck.
 
-As of 1.2.0, this mod should be compatible with the following mods:
+As of 1.3.0, this mod should be compatible with the following mods:
 
-- Cryptid/Talisman
-- Pokermon
+- [Cryptid](https://github.com/MathIsFun0/Cryptid/)/[Talisman](https://github.com/MathIsFun0/Talisman)
+- [Pokermon](https://github.com/InertSteak/Pokermon)
+- [Prism](https://github.com/blazingulag/Prism/)
+- [Reverie](https://github.com/jumbocarrot0/reverie)
 
 Please let me know of mods that add consumable cards that may need additional support.
 

--- a/sticky-fingers/lovely/button_callbacks.lua
+++ b/sticky-fingers/lovely/button_callbacks.lua
@@ -46,6 +46,9 @@ end
 G.FUNCS.can_select_card = base_can_select_card
 
 G.FUNCS.sticky_can_select_card = function(_card)
+  if Reverie and _card.ability.set == 'Cine' then
+    return (_card.edition and _card.edition.negative) or #G.cine_quests.cards < G.cine_quests.config.card_limit
+  end
   if Cryptid then
     -- https://github.com/MathIsFun0/Cryptid/blob/main/lib/overrides.lua#L1171-L1182
     if

--- a/sticky-fingers/lovely/button_callbacks.lua
+++ b/sticky-fingers/lovely/button_callbacks.lua
@@ -65,15 +65,6 @@ G.FUNCS.sticky_can_select_card = function(_card)
   end
 end
 
--- Taken from https://github.com/MathIsFun0/Cryptid/blob/main/items/code.lua#L5141
-G.FUNCS.cryptid_can_reserve_card = function(e)
-  if Cryptid then
-    local c1 = e
-    return #G.consumeables.cards
-        < G.consumeables.config.card_limit + (Cryptid.safe_get(c1, "edition", "negative") and 1 or 0)
-  end
-end
-
 --Checks if the cost of a non voucher card is greater than what the player can afford and changes the
 --buy button visuals accordingly
 --

--- a/sticky-fingers/lovely/button_callbacks.toml
+++ b/sticky-fingers/lovely/button_callbacks.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.copy]

--- a/sticky-fingers/lovely/card.toml
+++ b/sticky-fingers/lovely/card.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.pattern]

--- a/sticky-fingers/lovely/cardarea.toml
+++ b/sticky-fingers/lovely/cardarea.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.pattern]

--- a/sticky-fingers/lovely/controller.toml
+++ b/sticky-fingers/lovely/controller.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.pattern]

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -171,7 +171,7 @@ function create_drag_target_from_card(_card)
             end
         end
 
-        -- Cines (Reverie) cards inside their own area.
+        -- 'Cine' (Reverie) cards inside their own area.
         if _card.area == G.cine_quests then
             if _card.ability.set == 'Cine' then
                 -- Cine sell drag target

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -1,6 +1,3 @@
-debug_current_card = {}
-
-
 local sticky_fingers_drag_areas_mods = {
     -- Prism's double cards from hand. "Switch" area.
     {
@@ -162,9 +159,8 @@ local find_matching_areas_for_card = function(_card)
     return matches
 end
 
-function create_drag_target_from_card(_card2)
+function create_drag_target_from_card(_card)
     if _card and G.STAGE == G.STAGES.RUN then
-        debug_current_card = _card;
         G.DRAG_TARGETS = G.DRAG_TARGETS or {
             S_buy = Moveable { T = { x = G.jokers.T.x, y = G.jokers.T.y - 0.1, w = G.consumeables.T.x + G.consumeables.T.w - G.jokers.T.x, h = G.jokers.T.h + 0.6 } },
             S_buy_and_use = Moveable { T = { x = G.deck.T.x + 0.2, y = G.deck.T.y - 5.1, w = G.deck.T.w - 0.1, h = 4.5 } },

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -48,11 +48,13 @@ function create_drag_target_from_card(_card)
                         G.FUNCS.use_card({ config = { ref_table = other } })
                     elseif other.ability.set == 'Booster' and G.FUNCS.can_buy(other) then
                         G.FUNCS.use_card({ config = { ref_table = other } })
-                    elseif other.ability.set == 'Tag' and G.FUNCS.can_buy(other) then
-                        G.FUNCS.use_card({ config = { ref_table = other } })
-                        -- Welp, I sure hope this doesn't crash anything
                     elseif G.FUNCS.can_buy(other) then
-                        G.FUNCS.use_card({ config = { ref_table = other } })
+                        G.FUNCS.buy_from_shop({
+                            config = {
+                                ref_table = other,
+                                id = 'buy'
+                            }
+                        })
                     end
                 end)
             })
@@ -172,7 +174,6 @@ function create_drag_target_from_card(_card)
         -- Cines (Reverie) cards inside their own area.
         if _card.area == G.cine_quests then
             if _card.ability.set == 'Cine' then
-                print(inspect(_card.ability))
                 -- Cine sell drag target
                 local sell_loc = copy_table(localize('ml_sell_target'))
                 sell_loc[#sell_loc + 1] = '$' .. (_card.facing == 'back' and '?' or _card.sell_cost)

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -48,6 +48,8 @@ function create_drag_target_from_card(_card)
                         G.FUNCS.use_card({ config = { ref_table = other } })
                     elseif other.ability.set == 'Booster' and G.FUNCS.can_buy(other) then
                         G.FUNCS.use_card({ config = { ref_table = other } })
+                    elseif other.ability.set == 'Tag' and G.FUNCS.can_buy(other) then
+                        G.FUNCS.use_card({ config = { ref_table = other } })
                     end
                 end)
             })

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -252,6 +252,28 @@ function create_drag_target_from_card(_card)
                 })
             end
         end
+
+        if _card.area == G.hand then
+            -- Prism's double cards from hand
+            if G.PRISM and _card.ability.set == 'Enhanced' and _card.ability.name == 'm_prism_double' then
+                drag_target({
+                    cover = G.DRAG_TARGETS.P_select,
+                    colour = adjust_alpha(G.C.RED, 0.9),
+                    text = { localize('prism_switch') },
+                    card = _card,
+                    active_check = (function(other)
+                        return true
+                    end),
+                    release_func = (function(other)
+                        G.FUNCS.switch_button({
+                            config = {
+                                ref_table = other,
+                            }
+                        })
+                    end)
+                })
+            end
+        end
     end
 end
 

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -77,7 +77,7 @@ function create_drag_target_from_card(_card)
         end
 
         if _card.area and (_card.area == G.pack_cards) then
-            -- Cryptid code cards
+            -- Cryptid code cards inside packs
             if Cryptid and _card.ability.consumeable and _card.ability.set == 'Code' then
                 drag_target({
                     cover = G.DRAG_TARGETS.P_save,
@@ -94,7 +94,7 @@ function create_drag_target_from_card(_card)
                     end),
                 })
             end
-            -- Pokermon item/energy cards
+            -- Pokermon item/energy cards inside packs
             if pokermon and _card.ability.consumeable and (_card.ability.set == 'Energy' or _card.ability.set == 'Item') then
                 drag_target({
                     cover = G.DRAG_TARGETS.P_save,
@@ -111,7 +111,25 @@ function create_drag_target_from_card(_card)
                     end),
                 })
             end
-            if _card.ability.consumeable and not (_card.ability.set == 'Planet') then
+            -- Cine (Reverie) cards inside packs
+            if _card.ability.consumeable and _card.ability.set == 'Cine' then
+                drag_target({
+                    cover = G.DRAG_TARGETS.P_select,
+                    colour = adjust_alpha(G.C.GREEN, 0.9),
+                    text = { localize('b_select') },
+                    card = _card,
+                    active_check = (function(other)
+                        return G.FUNCS.sticky_can_select_card(other)
+                    end),
+                    release_func = (function(other)
+                        if G.FUNCS.sticky_can_select_card(other) then
+                            G.FUNCS.use_card({ config = { ref_table = other } })
+                        end
+                    end)
+                })
+            end
+
+            if _card.ability.consumeable and not (_card.ability.set == 'Planet' or _card.ability.set == 'Cine') then
                 drag_target({
                     cover = G.DRAG_TARGETS.C_use,
                     colour = adjust_alpha(G.C.RED, 0.9),
@@ -138,6 +156,43 @@ function create_drag_target_from_card(_card)
                     release_func = (function(other)
                         if G.FUNCS.sticky_can_select_card(other) then
                             G.FUNCS.use_card({ config = { ref_table = other } })
+                        end
+                    end)
+                })
+            end
+        end
+
+        -- Cines (Reverie) cards inside their own area.
+        if _card.area == G.cine_quests then
+            if _card.ability.set == 'Cine' then
+                print(inspect(_card.ability))
+                -- Cine sell drag target
+                local sell_loc = copy_table(localize('ml_sell_target'))
+                sell_loc[#sell_loc + 1] = '$' .. (_card.facing == 'back' and '?' or _card.sell_cost)
+                drag_target({
+                    cover = G.DRAG_TARGETS.C_sell,
+                    colour = adjust_alpha(G.C.GOLD, 0.9),
+                    text = sell_loc,
+                    card = _card,
+                    active_check = (function(other)
+                        return other:can_sell_card()
+                    end),
+                    release_func = (function(other)
+                        G.FUNCS.sell_card { config = { ref_table = other } }
+                    end)
+                })
+                drag_target({
+                    cover = G.DRAG_TARGETS.J_sell_vanilla,
+                    colour = adjust_alpha(G.C.RED, 0.9),
+                    text = { localize('b_use') },
+                    card = _card,
+                    active_check = (function(other)
+                        return other:can_use_consumeable()
+                    end),
+                    release_func = (function(other)
+                        G.FUNCS.use_card({ config = { ref_table = other } })
+                        if G.OVERLAY_TUTORIAL and G.OVERLAY_TUTORIAL.button_listen == 'use_card' then
+                            G.FUNCS.tut_next()
                         end
                     end)
                 })

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -50,6 +50,9 @@ function create_drag_target_from_card(_card)
                         G.FUNCS.use_card({ config = { ref_table = other } })
                     elseif other.ability.set == 'Tag' and G.FUNCS.can_buy(other) then
                         G.FUNCS.use_card({ config = { ref_table = other } })
+                        -- Welp, I sure hope this doesn't crash anything
+                    elseif G.FUNCS.can_buy(other) then
+                        G.FUNCS.use_card({ config = { ref_table = other } })
                     end
                 end)
             })

--- a/sticky-fingers/lovely/misc_functions.lua
+++ b/sticky-fingers/lovely/misc_functions.lua
@@ -19,8 +19,10 @@ function create_drag_target_from_card(_card)
         end
 
         if _card.area and (_card.area == G.shop_jokers or _card.area == G.shop_vouchers or _card.area == G.shop_booster) then
-            local buy_loc = copy_table(localize((_card.area == G.shop_vouchers and 'ml_redeem_target') or
-                (_card.area == G.shop_booster and 'ml_open_target') or 'ml_buy_target'))
+            local is_booster = _card.ability.set == 'Booster'
+            local is_voucher = _card.ability.set == 'Voucher'
+            local buy_loc = copy_table(localize((is_voucher and 'ml_redeem_target') or
+                (is_booster and 'ml_open_target') or 'ml_buy_target'))
             buy_loc[#buy_loc + 1] = '$' .. _card.cost
             drag_target({
                 cover = G.DRAG_TARGETS.S_buy,
@@ -31,7 +33,7 @@ function create_drag_target_from_card(_card)
                     return G.FUNCS.can_buy(other)
                 end),
                 release_func = (function(other)
-                    if other.area == G.shop_jokers and G.FUNCS.can_buy(other) then
+                    if other.ability.set == 'Joker' and G.FUNCS.can_buy(other) then
                         if G.OVERLAY_TUTORIAL and G.OVERLAY_TUTORIAL.button_listen == 'buy_from_shop' then
                             G.FUNCS.tut_next()
                         end
@@ -42,9 +44,9 @@ function create_drag_target_from_card(_card)
                             }
                         })
                         return
-                    elseif other.area == G.shop_vouchers and G.FUNCS.can_buy(other) then
+                    elseif other.ability.set == 'Voucher' and G.FUNCS.can_buy(other) then
                         G.FUNCS.use_card({ config = { ref_table = other } })
-                    elseif other.area == G.shop_booster and G.FUNCS.can_buy(other) then
+                    elseif other.ability.set == 'Booster' and G.FUNCS.can_buy(other) then
                         G.FUNCS.use_card({ config = { ref_table = other } })
                     end
                 end)

--- a/sticky-fingers/lovely/misc_functions.toml
+++ b/sticky-fingers/lovely/misc_functions.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.copy]

--- a/sticky-fingers/lovely/ui.toml
+++ b/sticky-fingers/lovely/ui.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.pattern]

--- a/sticky-fingers/lovely/ui_definitions.toml
+++ b/sticky-fingers/lovely/ui_definitions.toml
@@ -1,7 +1,7 @@
 [manifest]
 dump_lua = true
 priority = 0
-version = "1.2.0"
+version = "1.3.0"
 
 [[patches]]
 [patches.pattern]

--- a/sticky-fingers/touch-mode.json
+++ b/sticky-fingers/touch-mode.json
@@ -9,6 +9,6 @@
   "badge_colour": "666665",
   "badge_text_colour": "FFFFFF",
   "display_name": "Sticky Fingers",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "dependencies": ["Steamodded (>=1.*)", "Lovely (>=0.6)"]
 }


### PR DESCRIPTION
- Adds support for [Reverie](https://github.com/jumbocarrot0/reverie) (should fix https://github.com/eramdam/sticky-fingers/issues/6)
- Adds support for [Prism](https://github.com/blazingulag/Prism/)
- Refactors mod cards logic
- Tweaks logic so boosters/vouchers/tags can be bought/opened even if they're not in their respective shop area (but they _do_ have to be in the shop)

![CleanShot_2025-03-24_at_13 57 162x](https://github.com/user-attachments/assets/8ea093e1-2c95-466e-a86e-f46b0b5973f0)
![CleanShot 2025-03-24 at 09 34 40@2x](https://github.com/user-attachments/assets/5fb754a9-0e8f-45cd-8faa-0f58d018a1e0)
![CleanShot 2025-03-24 at 09 35 21@2x](https://github.com/user-attachments/assets/3a2ec26f-bdc0-4206-b7cf-65b2d5864e02)
![CleanShot 2025-03-24 at 09 35 34@2x](https://github.com/user-attachments/assets/f331cdc4-973b-4731-864c-f62a85388744)
